### PR TITLE
Invoke the user's default shell in yb-env

### DIFF
--- a/templates/yb-env2.template
+++ b/templates/yb-env2.template
@@ -18,5 +18,5 @@ export WINE="$WINELOADER"
 if [ "$#" -gt 0 ]; then
     exec "$@"
 else
-    exec /bin/sh
+    exec "$SHELL"
 fi


### PR DESCRIPTION
By default `yb-env` was launching /bin/sh, but we can get the user's default shell from `$SHELL`. Launch that instead.